### PR TITLE
Less nesting for dispatcher

### DIFF
--- a/lib/thrifter.rb
+++ b/lib/thrifter.rb
@@ -77,12 +77,10 @@ module Thrifter
       include Concord.new(:app, :transport, :client)
 
       def call(rpc)
-        begin
-          transport.open
-          client.send rpc.name, *rpc.args
-        ensure
-          transport.close
-        end
+        transport.open
+        client.send rpc.name, *rpc.args
+      ensure
+        transport.close
       end
     end
 


### PR DESCRIPTION
No need to add a begin block since we only do one thing inside this
method call we can just ensure on the method.
