### PR TITLE
Fix dependency for bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(DOCKER_IMAGES):
 	mkdir -p $(@D)
 	touch $@
 		
-$(BUNDLE): Dockerfile thrifter.gemspec
+$(BUNDLE): Dockerfile thrifter.gemspec $(DOCKER_IMAGES)
 	docker build -t $(BUNDLE_IMAGE) .
 	docker inspect -f '{{ .Id }}' $(BUNDLE_IMAGE) >> $(DOCKER_IMAGES)
 


### PR DESCRIPTION
We need to have the `tmp` directory and file before we can append the
container ID.
