### PR TITLE
Explicit retriable exceptions

### DIFF
--- a/lib/thrifter/extensions/retriable.rb
+++ b/lib/thrifter/extensions/retriable.rb
@@ -23,7 +23,7 @@ module Thrifter
         @client = client
         @tries = tries
         @interval = interval
-        @retriable = DEFAULT_RETRIABLE_ERRORS + retriable
+        @retriable = DEFAULT_RETRIABLE_ERRORS + Array(retriable)
       end
 
       private

--- a/lib/thrifter/extensions/retriable.rb
+++ b/lib/thrifter/extensions/retriable.rb
@@ -4,7 +4,7 @@ module Thrifter
   end
 
   module Retry
-    RETRIABLE_ERRORS = [
+    DEFAULT_RETRIABLE_ERRORS = [
       Thrift::TransportException,
       Thrift::ProtocolException,
       Thrift::ApplicationException,
@@ -23,7 +23,7 @@ module Thrifter
         @client = client
         @tries = tries
         @interval = interval
-        @retriable = retriable
+        @retriable = DEFAULT_RETRIABLE_ERRORS + retriable
       end
 
       private
@@ -38,7 +38,7 @@ module Thrifter
         begin
           counter = counter + 1
           client.send name, *args
-        rescue *(RETRIABLE_ERRORS + retriable) => ex
+        rescue *retriable => ex
           if counter < tries
             sleep interval
             retry

--- a/test/extensions/retry_test.rb
+++ b/test/extensions/retry_test.rb
@@ -53,7 +53,21 @@ class RetryTest < MiniTest::Unit::TestCase
 
     client = RetryClient.new
 
-    result = client.with_retry({ tries: 2, interval: 0.01, retriable: [KnownError] }).echo(:request)
+    result = client.with_retry({ tries: 2, interval: 0.01, retriable: KnownError }).echo(:request)
+
+    assert :response == result, 'return value incorrect'
+  end
+
+  def test_retries_on_exceptions_specified_in_array
+    thrift_client = mock
+    retries = sequence(:retries)
+    thrift_client.expects(:echo).with(:request).in_sequence(retries).raises(KnownError)
+    thrift_client.expects(:echo).with(:request).in_sequence(retries).returns(:response)
+    TestService::Client.stubs(:new).returns(thrift_client)
+
+    client = RetryClient.new
+
+    result = client.with_retry({ tries: 2, interval: 0.01, retriable: [ KnownError ] }).echo(:request)
 
     assert :response == result, 'return value incorrect'
   end

--- a/test/extensions/retry_test.rb
+++ b/test/extensions/retry_test.rb
@@ -15,7 +15,7 @@ class RetryTest < MiniTest::Unit::TestCase
   end
 
   def known_errors
-    Thrifter::Retry::RETRIABLE_ERRORS
+    Thrifter::Retry::DEFAULT_RETRIABLE_ERRORS
   end
 
   def test_does_not_retry_on_unexpected_errors


### PR DESCRIPTION
This PR allows specifying additional exceptions to retry on - for the `Thrifter::Retry` extension.
A new keyword argument `:retriable` has been introduced, which should be an array of allowed exceptions.
The array will be combined with the "global" `Thrifter::Retry::DEFAULT_RETRIABLE_ERRORS` set.