### PR TITLE
Add keep_alive config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ class MyClient < Thrifer.build(MyService::Client)
 
   # Network Settings
   config.rpc_timeout = 0.15
+  config.keep_alive = true
 
   # Required to instantiate the client!
   config.uri = 'tcp://foo:2383'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,10 @@ class FakeTransport
 
   end
 
+  def open?
+    false
+  end
+
   def close
 
   end


### PR DESCRIPTION
This commit introduces to the "keep alive" config setting. When this
flag is set, the transport is only closed on error. Otherwise it's kept
open. The flag defaults to true. This changes the default behavior of
opening a new connection for every RPC. It may be disabled by setting
config.keep_alive = false.