### PR TITLE
Fix retry in combination with error wrapping

### DIFF
--- a/lib/thrifter.rb
+++ b/lib/thrifter.rb
@@ -12,6 +12,10 @@ require 'middleware'
 require 'connection_pool'
 
 module Thrifter
+  ClientError = Tnt.boom do |ex|
+    "#{ex.class}: #{ex.message}"
+  end
+
   RPC = Struct.new(:name, :args)
 
   class MiddlewareStack < Middleware::Builder

--- a/lib/thrifter/extensions/retriable.rb
+++ b/lib/thrifter/extensions/retriable.rb
@@ -5,6 +5,7 @@ module Thrifter
 
   module Retry
     DEFAULT_RETRIABLE_ERRORS = [
+      ClientError,
       Thrift::TransportException,
       Thrift::ProtocolException,
       Thrift::ApplicationException,

--- a/lib/thrifter/middleware/error_wrapping.rb
+++ b/lib/thrifter/middleware/error_wrapping.rb
@@ -1,8 +1,4 @@
 module Thrifter
-  ClientError = Tnt.boom do |ex|
-    "#{ex.class}: #{ex.message}"
-  end
-
   class ErrorWrapping
     WRAP = [
       Thrift::TransportException,

--- a/test/extensions/retry_test.rb
+++ b/test/extensions/retry_test.rb
@@ -103,6 +103,10 @@ class RetryTest < MiniTest::Unit::TestCase
     assert_includes known_errors, Timeout::Error
   end
 
+  def test_retries_on_wrapped_client_error
+    assert_includes known_errors, Thrifter::ClientError
+  end
+
   def test_retries_on_econrefused
     assert_includes known_errors, Errno::ECONNREFUSED
   end


### PR DESCRIPTION
When you use both the retry and the error wrapping you could potentially
end up with errors not retried because they were wrapped.

This can be fixed by also retrying wrapped client errors.