### PR TITLE
Count Different error types

### DIFF
--- a/lib/thrifter/middleware/rpc_metrics.rb
+++ b/lib/thrifter/middleware/rpc_metrics.rb
@@ -14,7 +14,18 @@ module Thrifter
       response
     rescue Thrift::TransportException => ex
       statsd.increment "rpc.#{rpc.name}.error"
-      statsd.increment "rpc.#{rpc.name}.error.transport"
+      case ex.type
+      when Thrift::TransportException::UNKNOWN
+        statsd.increment "rpc.#{rpc.name}.error.transport.unknown"
+      when Thrift::TransportException::NOT_OPEN
+        statsd.increment "rpc.#{rpc.name}.error.transport.not_open"
+      when Thrift::TransportException::ALREADY_OPEN
+        statsd.increment "rpc.#{rpc.name}.error.transport.already_open"
+      when Thrift::TransportException::TIMED_OUT
+        statsd.increment "rpc.#{rpc.name}.error.transport.timeout"
+      when Thrift::TransportException::END_OF_FILE
+        statsd.increment "rpc.#{rpc.name}.error.transport.eof"
+      end
       raise ex
     rescue Thrift::ProtocolException => ex
       statsd.increment "rpc.#{rpc.name}.error"

--- a/lib/thrifter/middleware/rpc_metrics.rb
+++ b/lib/thrifter/middleware/rpc_metrics.rb
@@ -48,7 +48,30 @@ module Thrifter
       raise ex
     rescue Thrift::ApplicationException => ex
       statsd.increment "rpc.#{rpc.name}.error"
-      statsd.increment "rpc.#{rpc.name}.error.application"
+      case ex.type
+      when Thrift::ApplicationException::UNKNOWN
+        statsd.increment "rpc.#{rpc.name}.error.application.unknown"
+      when Thrift::ApplicationException::UNKNOWN_METHOD
+        statsd.increment "rpc.#{rpc.name}.error.application.unknown_method"
+      when Thrift::ApplicationException::INVALID_MESSAGE_TYPE
+        statsd.increment "rpc.#{rpc.name}.error.application.invalid_message_type"
+      when Thrift::ApplicationException::WRONG_METHOD_NAME
+        statsd.increment "rpc.#{rpc.name}.error.application.wrong_method_name"
+      when Thrift::ApplicationException::BAD_SEQUENCE_ID
+        statsd.increment "rpc.#{rpc.name}.error.application.bad_sequence_id"
+      when Thrift::ApplicationException::MISSING_RESULT
+        statsd.increment "rpc.#{rpc.name}.error.application.missing_result"
+      when Thrift::ApplicationException::INTERNAL_ERROR
+        statsd.increment "rpc.#{rpc.name}.error.application.internal_error"
+      when Thrift::ApplicationException::PROTOCOL_ERROR
+        statsd.increment "rpc.#{rpc.name}.error.application.protocol_error"
+      when Thrift::ApplicationException::INVALID_TRANSFORM
+        statsd.increment "rpc.#{rpc.name}.error.application.invalid_transform"
+      when Thrift::ApplicationException::INVALID_PROTOCOL
+        statsd.increment "rpc.#{rpc.name}.error.application.invalid_protocol"
+      when Thrift::ApplicationException::UNSUPPORTED_CLIENT_TYPE
+        statsd.increment "rpc.#{rpc.name}.error.application.unsupported_client_type"
+      end
       raise ex
     rescue Timeout::Error => ex
       statsd.increment "rpc.#{rpc.name}.error"

--- a/lib/thrifter/middleware/rpc_metrics.rb
+++ b/lib/thrifter/middleware/rpc_metrics.rb
@@ -29,7 +29,22 @@ module Thrifter
       raise ex
     rescue Thrift::ProtocolException => ex
       statsd.increment "rpc.#{rpc.name}.error"
-      statsd.increment "rpc.#{rpc.name}.error.protocol"
+      case ex.type
+      when Thrift::ProtocolException::UNKNOWN
+        statsd.increment "rpc.#{rpc.name}.error.protocol.unknown"
+      when Thrift::ProtocolException::INVALID_DATA
+        statsd.increment "rpc.#{rpc.name}.error.protocol.invalid_data"
+      when Thrift::ProtocolException::NEGATIVE_SIZE
+        statsd.increment "rpc.#{rpc.name}.error.protocol.negative_size"
+      when Thrift::ProtocolException::SIZE_LIMIT
+        statsd.increment "rpc.#{rpc.name}.error.protocol.size_limit"
+      when Thrift::ProtocolException::BAD_VERSION
+        statsd.increment "rpc.#{rpc.name}.error.protocol.bad_version"
+      when Thrift::ProtocolException::NOT_IMPLEMENTED
+        statsd.increment "rpc.#{rpc.name}.error.protocol.not_implemented"
+      when Thrift::ProtocolException::DEPTH_LIMIT
+        statsd.increment "rpc.#{rpc.name}.error.protocol.depth_limit"
+      end
       raise ex
     rescue Thrift::ApplicationException => ex
       statsd.increment "rpc.#{rpc.name}.error"

--- a/test/middleware/rpc_metrics_test.rb
+++ b/test/middleware/rpc_metrics_test.rb
@@ -252,13 +252,205 @@ class RpcMetricsTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_counts_application_exceptions
+  def test_counts_unknown_application_exceptions
     app = stub
-    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException)
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::UNKNOWN
+    ))
 
     statsd = mock
     statsd.expects(:time).yields
-    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.unknown")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_unknown_method_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::UNKNOWN_METHOD
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.unknown_method")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_invalid_message_type_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::INVALID_MESSAGE_TYPE
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.invalid_message_type")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_wrong_method_name_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::WRONG_METHOD_NAME
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.wrong_method_name")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_bad_sequence_id_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::BAD_SEQUENCE_ID
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.bad_sequence_id")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_missing_result_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::MISSING_RESULT
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.missing_result")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_internal_error_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::INTERNAL_ERROR
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.internal_error")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_protocol_error_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::PROTOCOL_ERROR
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.protocol_error")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_invalid_transform_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::INVALID_TRANSFORM
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.invalid_transform")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_invalid_protocol_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::INVALID_PROTOCOL
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.invalid_protocol")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ApplicationException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_unsupported_client_type_application_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ApplicationException.new(
+      Thrift::ApplicationException::UNSUPPORTED_CLIENT_TYPE
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.application.unsupported_client_type")
     statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
     statsd.expects(:increment).with("rpc.#{rpc.name}.error")
 

--- a/test/middleware/rpc_metrics_test.rb
+++ b/test/middleware/rpc_metrics_test.rb
@@ -119,13 +119,129 @@ class RpcMetricsTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_counts_protocol_exceptions
+  def test_counts_unknown_protocol_exceptions
     app = stub
-    app.stubs(:call).with(rpc).raises(Thrift::ProtocolException)
+    app.stubs(:call).with(rpc).raises(Thrift::ProtocolException.new(
+      Thrift::ProtocolException::UNKNOWN
+    ))
 
     statsd = mock
     statsd.expects(:time).yields
-    statsd.expects(:increment).with("rpc.#{rpc.name}.error.protocol")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.protocol.unknown")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ProtocolException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_invalid_data_protocol_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ProtocolException.new(
+      Thrift::ProtocolException::INVALID_DATA
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.protocol.invalid_data")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ProtocolException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_negative_size_protocol_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ProtocolException.new(
+      Thrift::ProtocolException::NEGATIVE_SIZE
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.protocol.negative_size")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ProtocolException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_size_limit_protocol_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ProtocolException.new(
+      Thrift::ProtocolException::SIZE_LIMIT
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.protocol.size_limit")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ProtocolException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_bad_version_protocol_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ProtocolException.new(
+      Thrift::ProtocolException::BAD_VERSION
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.protocol.bad_version")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ProtocolException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_not_implemented_protocol_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ProtocolException.new(
+      Thrift::ProtocolException::NOT_IMPLEMENTED
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.protocol.not_implemented")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error")
+
+    middleware = Thrifter::RpcMetrics.new app, statsd
+
+    assert_raises Thrift::ProtocolException do
+      middleware.call rpc
+    end
+  end
+
+  def test_counts_depth_limit_protocol_exceptions
+    app = stub
+    app.stubs(:call).with(rpc).raises(Thrift::ProtocolException.new(
+      Thrift::ProtocolException::DEPTH_LIMIT
+    ))
+
+    statsd = mock
+    statsd.expects(:time).yields
+    statsd.expects(:increment).with("rpc.#{rpc.name}.error.protocol.depth_limit")
     statsd.expects(:increment).with("rpc.#{rpc.name}.outgoing")
     statsd.expects(:increment).with("rpc.#{rpc.name}.error")
 

--- a/thrifter.gemspec
+++ b/thrifter.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "mocha"
-  spec.add_development_dependency "sidekiq"
+  spec.add_development_dependency "sidekiq", "~> 4.2"
   spec.add_development_dependency "sidekiq-thrift_arguments"
   spec.add_development_dependency "eventmachine"
 end


### PR DESCRIPTION
This PR adds new keys for each type (or reason) for a given thrift level
exception. Examples:

- rpc.NAME.error.transport.timeout
- rpc.NAME.error.application.bad_sequence_id