### PR TITLE
Add connection pool telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(THRIFT): test.thrift
 $(DOCKER_IMAGES):
 	mkdir -p $(@D)
 	touch $@
-		
+
 $(BUNDLE): Dockerfile thrifter.gemspec $(DOCKER_IMAGES)
 	docker build -t $(BUNDLE_IMAGE) .
 	docker inspect -f '{{ .Id }}' $(BUNDLE_IMAGE) >> $(DOCKER_IMAGES)

--- a/lib/thrifter.rb
+++ b/lib/thrifter.rb
@@ -33,6 +33,10 @@ module Thrifter
     def increment(*)
 
     end
+
+    def gauge(*)
+
+    end
   end
 
   RESERVED_METHODS = [
@@ -148,7 +152,7 @@ module Thrifter
         fail ArgumentError, 'URI did not contain port' unless @uri.port
       end
 
-      @pool = ConnectionPool.new size: config.pool_size.to_i, timeout: config.pool_timeout.to_f do
+      @pool = InstrumentedPool.new(statsd: config.statsd, size: config.pool_size.to_i, timeout: config.pool_timeout.to_f) do
         stack = MiddlewareStack.new
 
         stack.use config.stack
@@ -190,6 +194,8 @@ module Thrifter
     end
   end
 end
+
+require_relative 'thrifter/instrumented_pool'
 
 require_relative 'thrifter/extensions/ping'
 require_relative 'thrifter/extensions/retriable'

--- a/lib/thrifter/instrumented_pool.rb
+++ b/lib/thrifter/instrumented_pool.rb
@@ -1,0 +1,35 @@
+module Thrifter
+  class InstrumentedPool < ConnectionPool
+    attr_reader :statsd
+
+    def initialize(options = { }, &block)
+      super(options, &block)
+      @statsd = options.fetch(:statsd)
+    end
+
+    def checkout(*args)
+      statsd.time('thread_pool.latency') do
+        super.tap do |conn|
+          statsd.increment('thread_pool.checkout')
+          statsd.gauge('thread_pool.in_use', in_use)
+        end
+      end
+    rescue Timeout::Error => ex
+      statsd.increment('thead_pool.timeout')
+      raise ex
+    end
+
+    def checkin(*args)
+      super.tap do
+        statsd.increment('thread_pool.checkin')
+        statsd.gauge('thread_pool.in_use', in_use)
+      end
+    end
+
+    private
+
+    def in_use
+      (1 - (@available.length / @size.to_f)).round(2)
+    end
+  end
+end

--- a/lib/thrifter/instrumented_pool.rb
+++ b/lib/thrifter/instrumented_pool.rb
@@ -8,6 +8,7 @@ module Thrifter
     end
 
     def checkout(*args)
+      statsd.gauge('thread_pool.size', @size)
       statsd.time('thread_pool.latency') do
         super.tap do |conn|
           statsd.increment('thread_pool.checkout')
@@ -15,7 +16,7 @@ module Thrifter
         end
       end
     rescue Timeout::Error => ex
-      statsd.increment('thead_pool.timeout')
+      statsd.increment('thread_pool.timeout')
       raise ex
     end
 

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -99,7 +99,11 @@ class AcceptanceTest < MiniTest::Unit::TestCase
       config.pool_timeout = 75
     end
 
-    ConnectionPool.expects(:new).with(size: 50, timeout: 75)
+    Thrifter::InstrumentedPool.expects(:new).with({
+      statsd: client.config.statsd,
+      size: 50,
+      timeout: 75
+    })
 
     client.new
   end
@@ -111,7 +115,11 @@ class AcceptanceTest < MiniTest::Unit::TestCase
       config.pool_timeout = '75.5'
     end
 
-    ConnectionPool.expects(:new).with(size: 50, timeout: 75.5)
+    Thrifter::InstrumentedPool.expects(:new).with({
+      statsd: client.config.statsd,
+      size: 50,
+      timeout: 75.5
+    })
 
     client.new
   end

--- a/test/extensions/retry_test.rb
+++ b/test/extensions/retry_test.rb
@@ -28,6 +28,10 @@ class RetryTest < MiniTest::Unit::TestCase
     def time(*args)
       yield
     end
+
+    def gauge(*)
+
+    end
   end
 
   attr_reader :statsd

--- a/test/instrumented_pool_test.rb
+++ b/test/instrumented_pool_test.rb
@@ -1,0 +1,73 @@
+require_relative 'test_helper'
+
+class InstrumentedPoolTest < MiniTest::Unit::TestCase
+  class TestStatsd
+    attr_reader :timers, :gauges, :counters
+
+    def initialize
+      @timers = [ ]
+      @gauges = [ ]
+      @counters = [ ]
+    end
+
+    def clear
+      timers.clear
+      gauges.clear
+      counters.clear
+    end
+
+    def time(key)
+      timers << key
+      yield
+    end
+
+    def increment(key, value = 1)
+      counters << [ key, value ]
+    end
+
+    def gauge(key, value)
+      gauges << [ key, value ]
+    end
+  end
+
+  attr_reader :pool, :statsd
+
+  def setup
+    super
+
+    @statsd = TestStatsd.new
+    @pool = Thrifter::InstrumentedPool.new(size: 5, timeout: 5, statsd: statsd) do
+      :foo
+    end
+  end
+
+  def test_checkout_instrumentation
+    assert_equal :foo,  pool.checkout, 'Incorrect connection'
+
+    latency = statsd.timers.first
+    assert_equal 'thread_pool.latency', latency
+
+    counter = statsd.counters.first
+    assert_equal 'thread_pool.checkout', counter[0]
+    assert_equal 1, counter[1]
+
+    in_use = statsd.gauges.first
+    assert_equal 'thread_pool.in_use', in_use[0]
+    assert_equal 0.2, in_use[1]
+  end
+
+  def test_checkin_instrumentation
+    assert pool.checkout
+    statsd.clear
+
+    pool.checkin
+
+    counter = statsd.counters.first
+    assert_equal 'thread_pool.checkin', counter[0]
+    assert_equal 1, counter[1]
+
+    in_use = statsd.gauges.first
+    assert_equal 'thread_pool.in_use', in_use[0]
+    assert_equal 0.0, in_use[1]
+  end
+end


### PR DESCRIPTION
This commits adds:

- thread_pool.latency - Time to checkout a connection from the pool
- thread_pool.checkout - Counter on each checkout
- thread_pool.checkin - Counter on each checkin
- thread_pool.timeout - Counter on each checkout timeout
- thread_pool.in_use - Total active / total allocated guage
- thread_pool.size - size itself (this value does not change)